### PR TITLE
swap to non-centred parameterisation

### DIFF
--- a/src/stan/model_with_prior.stan
+++ b/src/stan/model_with_prior.stan
@@ -9,8 +9,8 @@ data {
     matrix[nteam, nfeat] X;
 }
 parameters {
-    vector<lower=0>[nteam] a;
-    vector<lower=0>[nteam] b;
+    vector[nteam] log_a_tilde;
+    vector[nteam] log_b_tilde;
     real<lower=0> gamma;
     real<lower=0> sigma_a;
     real<lower=0> sigma_b;
@@ -19,10 +19,12 @@ parameters {
     vector[nfeat] beta_b;
 }
 transformed parameters {
-    vector[nmatch] home_rate = a[home_team] .* b[away_team] * gamma;
-    vector[nmatch] away_rate = a[away_team] .* b[home_team];
     vector[nteam] mu_a = X * beta_a;
     vector[nteam] mu_b = beta_b_0 + X * beta_b;
+    vector[nteam] a = exp(mu_a + sigma_a * log_a_tilde);
+    vector[nteam] b = exp(mu_b + sigma_b * log_b_tilde);
+    vector[nmatch] home_rate = a[home_team] .* b[away_team] * gamma;
+    vector[nmatch] away_rate = a[away_team] .* b[home_team];
 }
 model {
     beta_a ~ normal(0, 1);
@@ -30,8 +32,8 @@ model {
     beta_b_0 ~ normal(0, 1);
     sigma_a ~ normal(0, 1);
     sigma_b ~ normal(0, 1);
-    a ~ lognormal(mu_a, sigma_a);
-    b ~ lognormal(mu_b, sigma_b);
+    log_a_tilde ~ normal(0, 1);
+    log_b_tilde ~ normal(0, 1);
     gamma ~ lognormal(0, 1);
     home_goals ~ poisson(home_rate);
     away_goals ~ poisson(away_rate);

--- a/src/stan/simple_model.stan
+++ b/src/stan/simple_model.stan
@@ -7,14 +7,16 @@ data {
     int away_goals[nmatch];
 }
 parameters {
-    vector<lower=0>[nteam] a;
-    vector<lower=0>[nteam] b;
+    vector[nteam] log_a_tilde;
+    vector[nteam] log_b_tilde;
     real<lower=0> gamma;
     real<lower=0> sigma_a;
     real<lower=0> sigma_b;
     real mu_b;
 }
 transformed parameters {
+    vector[nteam] a = exp(sigma_a * log_a_tilde);
+    vector[nteam] b = exp(mu_b + sigma_b * log_b_tilde);
     vector[nmatch] home_rate = a[home_team] .* b[away_team] * gamma;
     vector[nmatch] away_rate = a[away_team] .* b[home_team];
 }
@@ -23,8 +25,8 @@ model {
     sigma_a ~ normal(0, 1);
     sigma_b ~ normal(0, 1);
     mu_b ~ normal(0, 1);
-    a ~ lognormal(0, sigma_a);
-    b ~ lognormal(mu_b, sigma_b);
+    log_a_tilde ~ normal(0, 1);
+    log_b_tilde ~ normal(0, 1);
     home_goals ~ poisson(home_rate);
     away_goals ~ poisson(away_rate);
 }


### PR DESCRIPTION
Use the [non-centred parameterisation](https://arxiv.org/abs/1312.0906) to improve sampling. This fixes inefficient and biased sampling in the case where extra covariates were passed to the model.