### PR TITLE
pin pystan to 2.19 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "cython", "numpy", "pystan"]
+requires = ["setuptools", "wheel", "cython", "numpy", "pystan~=2.19.1.1"]


### PR DESCRIPTION
As per the thread over on AIrsenal, I believe this is needed for the model compilation to work successfully during setup.